### PR TITLE
Exclude source map from assets

### DIFF
--- a/src/HmrServer.js
+++ b/src/HmrServer.js
@@ -110,7 +110,11 @@ export default class HmrServer {
     const getLauncherFileName = () => {
       const assets = Object.values(stats.toJson().entrypoints).reduce((acc, group) => {
         return acc.concat(
-          ...group.assets.map(asset => path.resolve(stats.compilation.compiler.outputPath, asset))
+          ...group.assets
+            .filter(asset => !asset.endsWith('.map'))
+            .map(asset =>
+              path.resolve(stats.compilation.compiler.outputPath, asset)
+            )
         );
       }, []);
 

--- a/src/HmrServer.js
+++ b/src/HmrServer.js
@@ -112,9 +112,7 @@ export default class HmrServer {
         return acc.concat(
           ...group.assets
             .filter(asset => !asset.endsWith('.map'))
-            .map(asset =>
-              path.resolve(stats.compilation.compiler.outputPath, asset)
-            )
+            .map(asset => path.resolve(stats.compilation.compiler.outputPath, asset))
         );
       }, []);
 


### PR DESCRIPTION
There is a but that the assets are also loading in the `.map` files.

This fixes that bug.