### PR TITLE
Fix: Stricter check on asset type

### DIFF
--- a/src/HmrServer.js
+++ b/src/HmrServer.js
@@ -119,7 +119,7 @@ export default class HmrServer {
       const assets = Object.values(stats.toJson().entrypoints).reduce((acc, group) => {
         return acc.concat(
           ...group.assets
-            .filter((asset) => !asset.endsWith('.map'))
+            .filter((asset) => /\.[cm]?js$/i.test(asset))
             .map((asset) => path.resolve(stats.compilation.compiler.outputPath, asset))
         );
       }, []);


### PR DESCRIPTION
Avoids attempting to import assets such as `.css` files by checking that
each asset has one of the following extensions:
- `.js`
- `.cjs`
- `.mjs`

All other files will _not_ be `require()`'d.